### PR TITLE
TT-1518: Set project name to verify-eidas-notification

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-  - name: eidas-proxy-node
+  - name: verify-eidas-notification
     memory: 1G
     buildpack: java_buildpack
     path: ./build/distributions/verify-eidas-notification.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'verify-eidas-notification'


### PR DESCRIPTION
If we don't do this, the distribution ZIP that gets built is named
after the root directory. For example, on Jenkins you end up with a ZIP
called `workspace.zip` which is undesirable.

Setting the project name makes configuring Jenkins jobs much easier.

Author: @vixus0