### PR TITLE
BAU: Gradle cleanup and CONFIG_FILE check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,13 +20,6 @@ repositories {
 dependencies {
     compile ( 
         "io.dropwizard:dropwizard-core:${dropwizardVersion}",
-        "io.dropwizard:dropwizard-jetty:${dropwizardVersion}",
-        "io.dropwizard:dropwizard-assets:${dropwizardVersion}",
-        "io.dropwizard:dropwizard-client:${dropwizardVersion}",
-        "io.dropwizard:dropwizard-configuration:${dropwizardVersion}",
-        "io.dropwizard:dropwizard-logging:${dropwizardVersion}",
-        "io.dropwizard:dropwizard-views:${dropwizardVersion}",
-        "io.dropwizard:dropwizard-metrics-graphite:${dropwizardVersion}",
     )
     testCompile(
         'junit:junit:4.12',
@@ -43,18 +36,6 @@ pushToPaas.dependsOn distZip
 
 task wrapper(type: Wrapper) {
   gradleVersion = '3.3'
-}
-
-// Configure the jar task to build a fat jar
-jar {
-  from {
-    (configurations.compile).collect {
-      it.isDirectory() ? it : zipTree(it)
-    }
-  }
-  manifest {
-    attributes("Main-Class": mainClassName)
-  }
 }
 
 run {

--- a/src/main/java/uk/gov/ida/notification/EidasProxyNodeApplication.java
+++ b/src/main/java/uk/gov/ida/notification/EidasProxyNodeApplication.java
@@ -12,7 +12,13 @@ public class EidasProxyNodeApplication extends Application<EidasProxyNodeConfigu
 
     public static void main(final String[] args) throws Exception {
         if (args == null || args.length == 0) {
-            new EidasProxyNodeApplication().run("server", System.getenv("CONFIG_FILE"));
+            String configFile = System.getenv("CONFIG_FILE");
+
+            if (configFile == null) {
+                throw new RuntimeException("CONFIG_FILE environment variable should be set with path to configuration file");
+            }
+
+            new EidasProxyNodeApplication().run("server", configFile);
         } else {
             new EidasProxyNodeApplication().run(args);
         }


### PR DESCRIPTION
- Remove explicit dependency declarations in build.gradle (looks like
  dropwizard-core will take care of these for us.)
- Remove jar task configuration since we're using a distribution ZIP
  instead of a fat jar for PaaS (didn't seem to be working anyway).
- Make sure the application checks for the CONFIG_FILE environment
  variable before trying to start.

Author: @vixus0