### PR TITLE
BAU: Fix typo in paas deploy script

### DIFF
--- a/jenkins/paas.sh
+++ b/jenkins/paas.sh
@@ -29,4 +29,4 @@ else
 fi
 
 ./gradlew -x test pushToPaas
-./jenkins/acceptance.sh
+./jenkins/acceptance-test.sh


### PR DESCRIPTION
The acceptance test script is called `acceptance-test.sh`.

Author: @vixus0