### PR TITLE
BAU: Fix build.gradle for Gradle 4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,8 +66,8 @@ sourceSets {
 task acceptanceTest(type: Test) {
     description = 'Runs the acceptance tests'
     group = 'verification'
-    testClassesDir = sourceSets.acceptanceTest.output.classesDir
     classpath = sourceSets.acceptanceTest.runtimeClasspath
-    reports.junitXml.destination = "$buildDir/acceptance-test-results"
-    reports.html.destination = "$buildDir/reports/acceptance-test"
+    setTestClassesDirs sourceSets.acceptanceTest.output.classesDirs
+    reports.junitXml.setDestination new File("$buildDir/acceptance-test-results")
+    reports.html.setDestination new File("$buildDir/reports/acceptance-test")
 }


### PR DESCRIPTION
Running gradle was issuing the following messages about deprecated
behaviours:

```
Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set. This behaviour has been deprecated and is scheduled to be removed in Gradle 5.0
The setTestClassesDir(File) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the setTestClassesDirs(FileCollection) method instead.
The ConfigurableReport.setDestination(Object) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the method ConfigurableReport.setDestination(File) instead.
```

This fixes the acceptanceTest task in `build.gradle` to
use the updated behaviour and remove these error messages.

Author: @vixus0