### PR TITLE
BAU: run acceptance tests on local pre-commit but not on Jenkins

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -2,5 +2,4 @@
 
 set -e
 
-./pre-commit.sh
-
+./gradlew clean build

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-./gradlew clean build
+./jenkins/build.sh
 ./local-acceptance.sh


### PR DESCRIPTION
Running acceptance test requires stub-idp repo, which is available
locally, hence we should run it as part of pre-commit, but CI does not
require it since the PaaS acceptance test is run as part of deployment
to PaaS