### PR TITLE
BAU: Update Hub Url to point to Stub IDP on PaaS

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,7 +6,7 @@ applications:
     path: ./build/distributions/verify-eidas-notification.zip
     env:
       CONFIG_FILE: /app/verify-eidas-notification/config.yml
-      HUB_URL: https://verify-eidas-notification.cloudapps.digital/stub-idp/request
+      HUB_URL: https://verify-eidas-notification-stub-idp.cloudapps.digital/stub-idp/request
       CONNECTOR_NODE_URL: https://verify-eidas-notification.cloudapps.digital/connector-node/eidas-authn-response
       PROXY_NODE_HUB_RESPONSE_URL: https://verify-eidas-notification.cloudapps.digital/SAML2/Response/POST
       PROXY_NODE_AUTHN_REQUEST_URL: https://verify-eidas-notification.cloudapps.digital/SAML2/SSO/POST


### PR DESCRIPTION
Acceptance tests are failing due to Proxy Node not going to Stub IDP