### PR TITLE
TT-1707 Accept Authn Without SPType

### DIFF
--- a/src/main/java/uk/gov/ida/notification/saml/translation/EidasAuthnRequest.java
+++ b/src/main/java/uk/gov/ida/notification/saml/translation/EidasAuthnRequest.java
@@ -37,13 +37,20 @@ public class EidasAuthnRequest {
         String destination = request.getDestination();
         String requestedLoa = request.getRequestedAuthnContext().getAuthnContextClassRefs().get(0).getAuthnContextClassRef();
 
+        SPTypeEnumeration spType;
+
         XMLObject spTypeObj = request.getExtensions().getOrderedChildren()
                 .stream()
                 .filter(obj -> obj  instanceof  SPTypeImpl)
                 .findFirst()
-                .orElseThrow(() -> new EidasAuthnRequestException("eIDAS AuthnRequest has no SPType"));
+                .orElse(null);
 
-        SPTypeEnumeration spType = ((SPType) spTypeObj).getType();
+        if (spTypeObj == null) {
+            spType = new SPTypeEnumeration("public");
+        }
+        else {
+            spType = ((SPType) spTypeObj).getType();
+        }
 
         Optional<XMLObject> requestedAttributesObj = request.getExtensions().getOrderedChildren()
                 .stream()


### PR DESCRIPTION
CEF reference does not always send SPType with the authnrequest. This
appears to be by design because SPType can either be declared in the
Authnrequest or service provider meta data.

A quick fix for now is to default to public SPType until we are able to
consume service provider metadata.

Solo: @ejrowley