### PR TITLE
TT-1704: Using Connector Node metadata to fetch Connector Node's certs

### DIFF
--- a/src/dist/config.yml
+++ b/src/dist/config.yml
@@ -6,6 +6,13 @@ server:
     - type: http
       port: ${ADMIN_PORT:-6601}
 
+httpClient:
+  timeout: 15s
+  timeToLive: 10m
+  cookiesEnabled: false
+  connectionTimeout: 15s
+  minThreads: 8
+
 logging:
   level: INFO
   loggers:
@@ -18,7 +25,10 @@ logging:
 
 proxyNodeEntityId: ${PROXY_NODE_ENTITY_ID:-http://proxy-node.uk}
 hubUrl: ${HUB_URL:-/stub-idp/request}
+
 connectorNodeUrl: ${CONNECTOR_NODE_URL:-/connector-node/eidas-authn-response}
+connectorNodeMetadataUrl: ${CONNECTOR_NODE_METADATA_URL:-https://eidas-reference-14-connector.cloudapps.digital/ConnectorResponderMetadata}
+connectorNodeEntityId: ${CONNECTOR_NODE_ENTITY_ID:-https://eidas-reference-14-connector.cloudapps.digital/ConnectorResponderMetadata}
 
 hubFacingSigningKeyPair:
   publicKey:
@@ -35,5 +45,3 @@ hubFacingEncryptionKeyPair:
     name: proxy_node_encryption
   privateKey:
     keyFile: ${HUB_FACING_ENCRYPTION_KEY_FILE:-build/resources/main/local/proxy_node_encryption.pk8}
-
-

--- a/src/main/java/uk/gov/ida/notification/EidasProxyNodeConfiguration.java
+++ b/src/main/java/uk/gov/ida/notification/EidasProxyNodeConfiguration.java
@@ -2,6 +2,7 @@ package uk.gov.ida.notification;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
+import io.dropwizard.client.JerseyClientConfiguration;
 import uk.gov.ida.notification.pki.KeyPairConfiguration;
 
 import javax.validation.Valid;
@@ -23,6 +24,16 @@ public class EidasProxyNodeConfiguration extends Configuration {
     @JsonProperty
     @Valid
     @NotNull
+    private URI connectorNodeMetadataUrl;
+
+    @JsonProperty
+    @Valid
+    @NotNull
+    private String connectorNodeEntityId;
+
+    @JsonProperty
+    @Valid
+    @NotNull
     private String proxyNodeEntityId;
 
     @JsonProperty
@@ -34,6 +45,10 @@ public class EidasProxyNodeConfiguration extends Configuration {
     @Valid
     @NotNull
     private KeyPairConfiguration hubFacingEncryptionKeyPair;
+    @JsonProperty
+    @Valid
+    @NotNull
+    private JerseyClientConfiguration httpClient;
 
     public URI getHubUrl() {
         return hubUrl;
@@ -53,5 +68,17 @@ public class EidasProxyNodeConfiguration extends Configuration {
 
     public KeyPairConfiguration getHubFacingEncryptionKeyPair() {
         return hubFacingEncryptionKeyPair;
+    }
+
+    public JerseyClientConfiguration getHttpClientConfiguration() {
+        return httpClient;
+    }
+
+    public URI getConnectorNodeMetadataUrl() {
+        return connectorNodeMetadataUrl;
+    }
+
+    public String getConnectorNodeEntityId() {
+        return connectorNodeEntityId;
     }
 }

--- a/src/main/java/uk/gov/ida/notification/saml/metadata/JerseyClientMetadataResolver.java
+++ b/src/main/java/uk/gov/ida/notification/saml/metadata/JerseyClientMetadataResolver.java
@@ -1,0 +1,28 @@
+package uk.gov.ida.notification.saml.metadata;
+
+import org.opensaml.saml.metadata.resolver.impl.AbstractReloadingMetadataResolver;
+
+import javax.ws.rs.client.Client;
+import java.net.URI;
+import java.util.Timer;
+
+public class JerseyClientMetadataResolver extends AbstractReloadingMetadataResolver {
+    private final Client client;
+    private final URI metadataUri;
+
+    public JerseyClientMetadataResolver(Timer timer, Client client, URI metadataUri) {
+        super(timer);
+        this.client = client;
+        this.metadataUri = metadataUri;
+    }
+
+    @Override
+    protected String getMetadataIdentifier() {
+        return "metadata";
+    }
+
+    @Override
+    protected byte[] fetchMetadata() {
+        return client.target(metadataUri).request().get(String.class).getBytes();
+    }
+}

--- a/src/test/java/uk/gov/ida/notification/apprule/ConnectorNodeMetadataAppRuleTests.java
+++ b/src/test/java/uk/gov/ida/notification/apprule/ConnectorNodeMetadataAppRuleTests.java
@@ -1,23 +1,20 @@
 package uk.gov.ida.notification.apprule;
 
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.opensaml.saml.saml2.metadata.Endpoint;
-import org.opensaml.saml.saml2.metadata.EntitiesDescriptor;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.saml.saml2.metadata.KeyDescriptor;
 import org.opensaml.saml.saml2.metadata.RoleDescriptor;
 import org.opensaml.security.credential.UsageType;
+import uk.gov.ida.notification.apprule.base.ProxyNodeAppRuleTestBase;
 import uk.gov.ida.notification.saml.SamlParser;
 
 import javax.ws.rs.core.Response;
-import javax.xml.namespace.QName;
 import javax.xml.parsers.ParserConfigurationException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static java.util.function.Predicate.isEqual;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -25,9 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
-public class ConnectorNodeMetadataAppRuleTests {
-    @ClassRule
-    public static EidasProxyNodeAppRule proxyNodeAppRule = new EidasProxyNodeAppRule();
+public class ConnectorNodeMetadataAppRuleTests extends ProxyNodeAppRuleTestBase {
     private SamlParser parser;
 
     @Before

--- a/src/test/java/uk/gov/ida/notification/apprule/EidasAuthnRequestAppRuleTests.java
+++ b/src/test/java/uk/gov/ida/notification/apprule/EidasAuthnRequestAppRuleTests.java
@@ -2,9 +2,9 @@ package uk.gov.ida.notification.apprule;
 
 import org.glassfish.jersey.internal.util.Base64;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.opensaml.saml.saml2.core.AuthnRequest;
+import uk.gov.ida.notification.apprule.base.ProxyNodeAppRuleTestBase;
 import uk.gov.ida.notification.helpers.EidasAuthnRequestBuilder;
 import uk.gov.ida.notification.helpers.HtmlHelpers;
 import uk.gov.ida.notification.saml.SamlFormMessageType;
@@ -16,12 +16,9 @@ import javax.ws.rs.core.Form;
 
 import static org.junit.Assert.assertEquals;
 
-public class EidasAuthnRequestAppRuleTests {
+public class EidasAuthnRequestAppRuleTests extends ProxyNodeAppRuleTestBase {
     private SamlObjectMarshaller marshaller;
     private SamlParser parser;
-
-    @ClassRule
-    public static EidasProxyNodeAppRule proxyNodeAppRule = new EidasProxyNodeAppRule();
 
     @Before
     public void setup() throws Throwable {

--- a/src/test/java/uk/gov/ida/notification/apprule/HubMetadataAppRuleTests.java
+++ b/src/test/java/uk/gov/ida/notification/apprule/HubMetadataAppRuleTests.java
@@ -1,10 +1,10 @@
 package uk.gov.ida.notification.apprule;
 
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.opensaml.saml.saml2.metadata.EntitiesDescriptor;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import uk.gov.ida.notification.apprule.base.ProxyNodeAppRuleTestBase;
 import uk.gov.ida.notification.saml.SamlParser;
 
 import javax.ws.rs.core.Response;
@@ -17,9 +17,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
-public class HubMetadataAppRuleTests {
-    @ClassRule
-    public static EidasProxyNodeAppRule proxyNodeAppRule = new EidasProxyNodeAppRule();
+public class HubMetadataAppRuleTests extends ProxyNodeAppRuleTestBase {
     private SamlParser parser;
 
     @Before

--- a/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
+++ b/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
@@ -2,17 +2,14 @@ package uk.gov.ida.notification.apprule;
 
 import org.glassfish.jersey.internal.util.Base64;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AttributeValue;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.security.credential.BasicCredential;
 import org.opensaml.security.credential.Credential;
-import uk.gov.ida.notification.SamlInitializedTest;
+import uk.gov.ida.notification.apprule.base.ProxyNodeAppRuleTestBase;
 import uk.gov.ida.notification.helpers.HtmlHelpers;
 import uk.gov.ida.notification.pki.KeyPairConfiguration;
-import uk.gov.ida.notification.saml.SamlBuilder;
 import uk.gov.ida.notification.saml.SamlFormMessageType;
 import uk.gov.ida.notification.saml.SamlObjectMarshaller;
 import uk.gov.ida.notification.saml.SamlParser;
@@ -36,12 +33,9 @@ import javax.ws.rs.core.Form;
 import static org.junit.Assert.assertEquals;
 import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anAttributeStatement;
 
-public class HubResponseAppRuleTests extends SamlInitializedTest {
+public class HubResponseAppRuleTests extends ProxyNodeAppRuleTestBase {
     private SamlObjectMarshaller marshaller = new SamlObjectMarshaller();
     private SamlParser parser;
-
-    @ClassRule
-    public static EidasProxyNodeAppRule proxyNodeAppRule = new EidasProxyNodeAppRule();
 
     @Before
     public void setup() throws Throwable {
@@ -72,13 +66,13 @@ public class HubResponseAppRuleTests extends SamlInitializedTest {
         assertEquals(hubResponse.getInResponseTo(), eidasResponse.getInResponseTo());
     }
 
-    public static AssertionBuilder anAuthnStatementAssertion() {
+    private static AssertionBuilder anAuthnStatementAssertion() {
         return AssertionBuilder.anAssertion()
                 .addAuthnStatement(AuthnStatementBuilder.anAuthnStatement().build())
                 .addAttributeStatement(anAttributeStatement().addAttribute(IPAddressAttributeBuilder.anIPAddress().build()).build());
     }
 
-    public static AssertionBuilder aMatchingDatasetAssertion() {
+    private static AssertionBuilder aMatchingDatasetAssertion() {
         AttributeValue firstnameValue = PersonNameAttributeValueBuilder.aPersonNameValue().withValue("Jazzy").build();
         AttributeValue middlenameValue = PersonNameAttributeValueBuilder.aPersonNameValue().withValue("Harold").build();
         AttributeValue surnameValue = PersonNameAttributeValueBuilder.aPersonNameValue().withValue("Jefferson").build();
@@ -97,11 +91,5 @@ public class HubResponseAppRuleTests extends SamlInitializedTest {
 
         return AssertionBuilder.anAssertion()
                 .addAttributeStatement(attributeStatementBuilder.build());
-    }
-
-    public static Attribute anAttribute(String name) {
-        Attribute attribute = SamlBuilder.build(Attribute.DEFAULT_ELEMENT_NAME);
-        attribute.setName(name);
-        return attribute;
     }
 }

--- a/src/test/java/uk/gov/ida/notification/apprule/base/ProxyNodeAppRuleTestBase.java
+++ b/src/test/java/uk/gov/ida/notification/apprule/base/ProxyNodeAppRuleTestBase.java
@@ -1,0 +1,20 @@
+package uk.gov.ida.notification.apprule.base;
+
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.junit.DropwizardClientRule;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import uk.gov.ida.notification.apprule.rules.ConnectorNodeMetadataClientRule;
+import uk.gov.ida.notification.apprule.rules.EidasProxyNodeAppRule;
+
+public class ProxyNodeAppRuleTestBase {
+
+    @ClassRule
+    public static final DropwizardClientRule connectorNodeMetadata = new ConnectorNodeMetadataClientRule();
+
+    @Rule
+    public EidasProxyNodeAppRule proxyNodeAppRule = new EidasProxyNodeAppRule(
+            ConfigOverride.config("connectorNodeMetadataUrl", connectorNodeMetadata.baseUri() + "/connector-node/metadata"),
+            ConfigOverride.config("connectorNodeEntityId", "http://connector-node:8080/ConnectorResponderMetadata")
+    );
+}

--- a/src/test/java/uk/gov/ida/notification/apprule/rules/ConnectorNodeMetadataClientRule.java
+++ b/src/test/java/uk/gov/ida/notification/apprule/rules/ConnectorNodeMetadataClientRule.java
@@ -1,0 +1,55 @@
+package uk.gov.ida.notification.apprule.rules;
+
+import io.dropwizard.testing.junit.DropwizardClientRule;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.ls.DOMImplementationLS;
+import org.w3c.dom.ls.LSSerializer;
+import uk.gov.ida.notification.helpers.TestCertificates;
+import uk.gov.ida.notification.helpers.TestMetadataBuilder;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.StringWriter;
+
+public class ConnectorNodeMetadataClientRule extends DropwizardClientRule{
+
+    public ConnectorNodeMetadataClientRule(){
+        super(new TestConnectorNodeMetadataResource(getTestMetadata()));
+    }
+
+    private static Element getTestMetadata() {
+        try {
+            return new TestMetadataBuilder("connector_node_metadata_template.xml")
+                    .withEncryptionCert(TestCertificates.aX509Certificate())
+                    .buildElement();
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to create connector node's metadata for testing", e);
+        }
+    }
+
+    @Path("/connector-node")
+    public static class TestConnectorNodeMetadataResource {
+        private Element connectorNodeMetadata;
+
+        TestConnectorNodeMetadataResource(Element connectorNodeMetadata) {
+            this.connectorNodeMetadata = connectorNodeMetadata;
+        }
+
+        @GET
+        @Path("/metadata")
+        public String getMetadata() throws TransformerException {
+            StringWriter output = new StringWriter();
+
+            Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            transformer.transform(new DOMSource(connectorNodeMetadata), new StreamResult(output));
+
+            return output.toString();
+        }
+    }
+}

--- a/src/test/java/uk/gov/ida/notification/apprule/rules/EidasProxyNodeAppRule.java
+++ b/src/test/java/uk/gov/ida/notification/apprule/rules/EidasProxyNodeAppRule.java
@@ -1,4 +1,4 @@
-package uk.gov.ida.notification.apprule;
+package uk.gov.ida.notification.apprule.rules;
 
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.testing.ConfigOverride;
@@ -8,22 +8,31 @@ import uk.gov.ida.notification.EidasProxyNodeConfiguration;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
-
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 
 public class EidasProxyNodeAppRule extends DropwizardAppRule<EidasProxyNodeConfiguration> {
     private Client client;
 
-    public EidasProxyNodeAppRule() {
+    public EidasProxyNodeAppRule(ConfigOverride... configOverrides) {
         super(
-                EidasProxyNodeApplication.class,
-                resourceFilePath("config.yml"),
-                ConfigOverride.config("server.applicationConnectors[0].port", "0"),
-                ConfigOverride.config("server.adminConnectors[0].port", "0")
+            EidasProxyNodeApplication.class,
+            resourceFilePath("config.yml"),
+            getConfigOverrides(configOverrides)
         );
+    }
+
+    private static ConfigOverride[] getConfigOverrides(ConfigOverride... configOverrides) {
+        List<ConfigOverride> configOverridesList = new ArrayList<>(Arrays.asList(configOverrides));
+        configOverridesList.add(ConfigOverride.config("server.applicationConnectors[0].port", "0"));
+        configOverridesList.add(ConfigOverride.config("server.adminConnectors[0].port", "0"));
+        configOverridesList.add(ConfigOverride.config("server.adminConnectors[0].port", "0"));
+        return configOverridesList.toArray(new ConfigOverride[0]);
     }
 
     public WebTarget target(String path) throws URISyntaxException {

--- a/src/test/java/uk/gov/ida/notification/helpers/TestMetadataBuilder.java
+++ b/src/test/java/uk/gov/ida/notification/helpers/TestMetadataBuilder.java
@@ -8,6 +8,7 @@ import org.opensaml.core.config.InitializationService;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.DOMMetadataResolver;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 
@@ -24,7 +25,7 @@ import java.text.MessageFormat;
 import java.util.Base64;
 import java.util.HashMap;
 
-public class TestMetadataResolverBuilder {
+public class TestMetadataBuilder {
 
     private final Document metadataDocument;
     private final String SIGNING = "signing";
@@ -32,7 +33,7 @@ public class TestMetadataResolverBuilder {
     private final String md = "urn:oasis:names:tc:SAML:2.0:metadata";
     private final String ds = "http://www.w3.org/2000/09/xmldsig#";
 
-    public TestMetadataResolverBuilder(String metadataTemplateFileName) throws Exception {
+    public TestMetadataBuilder(String metadataTemplateFileName) throws Exception {
         String metadataString = FileHelpers.readFileAsString(metadataTemplateFileName);
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
@@ -40,39 +41,43 @@ public class TestMetadataResolverBuilder {
         metadataDocument = builder.parse(new InputSource(new StringReader(metadataString)));
     }
 
-    public TestMetadataResolverBuilder withEncryptionCert(String certificateString) throws XPathExpressionException, CertificateEncodingException {
+    public TestMetadataBuilder withEncryptionCert(String certificateString) throws XPathExpressionException, CertificateEncodingException {
         setCertificate(certificateString, ENCRYPTION);
         return this;
     }
 
-    public TestMetadataResolverBuilder withEncryptionCert(X509Certificate certificate) throws XPathExpressionException, CertificateEncodingException {
+    public TestMetadataBuilder withEncryptionCert(X509Certificate certificate) throws XPathExpressionException, CertificateEncodingException {
         String encodedCertificate = encodeCertificate(certificate);
         return withEncryptionCert(encodedCertificate);
     }
 
-    public TestMetadataResolverBuilder withNoEncryptionCert() throws XPathExpressionException {
+    public TestMetadataBuilder withNoEncryptionCert() throws XPathExpressionException {
         Node encryptionNode = findMetadataCertificateNode(ENCRYPTION);
         encryptionNode.getParentNode().removeChild(encryptionNode);
         return this;
     }
 
-    public TestMetadataResolverBuilder withSigningCert(String certificateString) throws XPathExpressionException, CertificateEncodingException {
+    public TestMetadataBuilder withSigningCert(String certificateString) throws XPathExpressionException, CertificateEncodingException {
         setCertificate(certificateString, SIGNING);
         return this;
     }
 
-    public TestMetadataResolverBuilder withSigningCert(X509Certificate certificate) throws XPathExpressionException, CertificateEncodingException {
+    public TestMetadataBuilder withSigningCert(X509Certificate certificate) throws XPathExpressionException, CertificateEncodingException {
         String encodedCertificate = encodeCertificate(certificate);
         return withSigningCert(encodedCertificate);
     }
 
-    public TestMetadataResolverBuilder withNoSigningCert() throws XPathExpressionException {
+    public TestMetadataBuilder withNoSigningCert() throws XPathExpressionException {
         Node signingNode = findMetadataCertificateNode(SIGNING);
         signingNode.getParentNode().removeChild(signingNode);
         return this;
     }
 
-    public MetadataResolver build(String metadataResolverId) throws ComponentInitializationException, InitializationException {
+    public Element buildElement() {
+        return metadataDocument.getDocumentElement();
+    }
+
+    public MetadataResolver buildResolver(String metadataResolverId) throws ComponentInitializationException, InitializationException {
         InitializationService.initialize();
         DOMMetadataResolver metadataResolver = new DOMMetadataResolver(metadataDocument.getDocumentElement());
         BasicParserPool parserPool = new BasicParserPool();

--- a/src/test/java/uk/gov/ida/notification/saml/metadata/ConnectorNodeMetadataTest.java
+++ b/src/test/java/uk/gov/ida/notification/saml/metadata/ConnectorNodeMetadataTest.java
@@ -8,7 +8,7 @@ import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.security.impl.MetadataCredentialResolver;
 import uk.gov.ida.notification.exceptions.MissingMetadataException;
 import uk.gov.ida.notification.helpers.TestCertificates;
-import uk.gov.ida.notification.helpers.TestMetadataResolverBuilder;
+import uk.gov.ida.notification.helpers.TestMetadataBuilder;
 
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
@@ -28,9 +28,9 @@ public class ConnectorNodeMetadataTest {
         X509Certificate encryptionCert = TestCertificates.aX509Certificate();
         PublicKey expectedPublicKey = encryptionCert.getPublicKey();
 
-        MetadataResolver metadataResolver = new TestMetadataResolverBuilder(TEST_CONNECTOR_NODE_METADATA_FILE)
+        MetadataResolver metadataResolver = new TestMetadataBuilder(TEST_CONNECTOR_NODE_METADATA_FILE)
                 .withEncryptionCert(encryptionCert)
-                .build("someId");
+                .buildResolver("someId");
         MetadataCredentialResolver metadataCredentialResolver = new MetadataCredentialResolverBuilder(metadataResolver).build();
 
         ConnectorNodeMetadata connectorNodeMetadata = new ConnectorNodeMetadata(metadataCredentialResolver, CONNECTOR_NODE_METADATA_ENTITY_ID);
@@ -41,9 +41,9 @@ public class ConnectorNodeMetadataTest {
 
     @Test(expected = MissingMetadataException.class)
     public void shouldErrorIfEncryptionPublicKeyElementIsEmpty() throws Exception {
-        MetadataResolver metadataResolver = new TestMetadataResolverBuilder(TEST_CONNECTOR_NODE_METADATA_FILE)
+        MetadataResolver metadataResolver = new TestMetadataBuilder(TEST_CONNECTOR_NODE_METADATA_FILE)
                 .withEncryptionCert("")
-                .build("someId");
+                .buildResolver("someId");
         MetadataCredentialResolver metadataCredentialResolver = new MetadataCredentialResolverBuilder(metadataResolver).build();
 
         ConnectorNodeMetadata connectorNodeMetadata = new ConnectorNodeMetadata(metadataCredentialResolver, CONNECTOR_NODE_METADATA_ENTITY_ID);
@@ -52,9 +52,9 @@ public class ConnectorNodeMetadataTest {
 
     @Test(expected = MissingMetadataException.class)
     public void shouldErrorIfNoEncryptionPublicKeyElement() throws Exception {
-        MetadataResolver metadataResolver = new TestMetadataResolverBuilder(TEST_CONNECTOR_NODE_METADATA_FILE)
+        MetadataResolver metadataResolver = new TestMetadataBuilder(TEST_CONNECTOR_NODE_METADATA_FILE)
                 .withNoEncryptionCert()
-                .build("someId");
+                .buildResolver("someId");
         MetadataCredentialResolver metadataCredentialResolver = new MetadataCredentialResolverBuilder(metadataResolver).build();
 
         ConnectorNodeMetadata connectorNodeMetadata = new ConnectorNodeMetadata(metadataCredentialResolver, CONNECTOR_NODE_METADATA_ENTITY_ID);

--- a/start-proxy-node.sh
+++ b/start-proxy-node.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # Start proxy-node locally
 
 APP_NAME="verify-eidas-notification"

--- a/start-stub-idp.sh
+++ b/start-stub-idp.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # Start stub-idp locally
 
 REMOTE="git@github.com:alphagov/ida-stub-idp"

--- a/startup.sh
+++ b/startup.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # Kill old services
 ./kill-service.sh 2>/dev/null
 


### PR DESCRIPTION
Currently using metadata from CEF ref in PaaS since we don't have a local CEF ref yet

- Added metadata resolvers to application startup.
- Changed app rule tests to contain a stub connector node metadata so
  integration tests will still run
- Fetch encryption certificate when receiving an IDP response

pair: @alan-gds @minhngocd @adrianw1832