### PR TITLE
BAU: Rename proxy node PaaS app

### DIFF
--- a/jenkins/acceptance-test.sh
+++ b/jenkins/acceptance-test.sh
@@ -4,7 +4,7 @@ set -e
 
 export SERVICE_PROVIDER_URL="https://eidas-joint-14-sp.cloudapps.digital"
 export CONNECTOR_NODE_URL="https://eidas-joint-14-connector.cloudapps.digital"
-export PROXY_NODE_URL="https://verify-eidas-notification.cloudapps.digital"
+export PROXY_NODE_URL="https://verify-eidas-notification-proxy-node.cloudapps.digital"
 export STUB_IDP_URL="https://verify-eidas-notification-stub-idp.cloudapps.digital"
 export HUB_URL="$STUB_IDP_URL/stub-idp-demo/SAML2/SSO"
 export CITIZEN_COUNTRY="UK_PN"

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-  - name: verify-eidas-notification
+  - name: verify-eidas-notification-proxy-node
     memory: 1G
     buildpack: java_buildpack
     path: ./build/distributions/verify-eidas-notification.zip
@@ -11,8 +11,8 @@ applications:
       CONNECTOR_NODE_METADATA_URL: https://eidas-joint-14-connector.cloudapps.digital/ConnectorResponderMetadata
       CONNECTOR_NODE_ENTITY_ID: https://eidas-joint-14-connector.cloudapps.digital/ConnectorResponderMetadata
       CONNECTOR_NODE_ISSUER_ID: https://eidas-joint-14-connector.cloudapps.digital/ConnectorMetadata
-      PROXY_NODE_HUB_RESPONSE_URL: https://verify-eidas-notification.cloudapps.digital/SAML2/Response/POST
-      PROXY_NODE_AUTHN_REQUEST_URL: https://verify-eidas-notification.cloudapps.digital/SAML2/SSO/POST
+      PROXY_NODE_HUB_RESPONSE_URL: https://verify-eidas-notification-proxy-node.cloudapps.digital/SAML2/Response/POST
+      PROXY_NODE_AUTHN_REQUEST_URL: https://verify-eidas-notification-proxy-node.cloudapps.digital/SAML2/SSO/POST
       HUB_FACING_SIGNING_CERT_FILE: /app/verify-eidas-notification/pki/proxy_node_signing.crt
       HUB_FACING_SIGNING_KEY_FILE: /app/verify-eidas-notification/pki/proxy_node_signing.pk8
       HUB_FACING_ENCRYPTION_CERT_FILE: /app/verify-eidas-notification/pki/proxy_node_encryption.crt

--- a/src/main/resources/paas/metadata_for_connector_node.xml
+++ b/src/main/resources/paas/metadata_for_connector_node.xml
@@ -108,9 +108,9 @@ validUntil="2115-05-24T19:30:26.624Z">
     <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
     <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
     <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-                            Location="https://verify-eidas-notification.cloudapps.digital/SAML2/SSO/POST"/>
+                            Location="https://verify-eidas-notification-proxy-node.cloudapps.digital/SAML2/SSO/POST"/>
     <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
-                            Location="https://verify-eidas-notification.cloudapps.digital/SAML2/SSO/Redirect"/>
+                            Location="https://verify-eidas-notification-proxy-node.cloudapps.digital/SAML2/SSO/Redirect"/>
     <saml2:Attribute
         FriendlyName="PersonIdentifier"
         Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier"

--- a/src/main/resources/paas/metadata_for_hub.xml
+++ b/src/main/resources/paas/metadata_for_hub.xml
@@ -116,7 +116,7 @@ Yg7EapvmkmJ9J6R+pMl+2cY451WxkTvcGtfHcUbBKElQmlwE/NEQJaNomx+4CgS5
         </ds:X509Data>
       </ds:KeyInfo>
     </md:KeyDescriptor>
-    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://verify-eidas-notification.cloudapps.digital/SAML2/SSO/Response/POST" index="1" isDefault="true" xsi:type="md:IndexedEndpointType"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://verify-eidas-notification-proxy-node.cloudapps.digital/SAML2/SSO/Response/POST" index="1" isDefault="true" xsi:type="md:IndexedEndpointType"/>
   </md:SPSSODescriptor>
   <md:Organization xsi:type="md:OrganizationType">
     <md:OrganizationName xml:lang="en-GB" xsi:type="md:localizedNameType">Hub</md:OrganizationName>


### PR DESCRIPTION
To make it clear what's running on PaaS, we should suffix `-proxy-node`
to the PaaS URL to match `verify-eidas-notification-stub-idp`.

Author: @vixus0