### PR TITLE
EID-1007: Update startup.sh to work with renamed repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,8 @@ buildNumber.properties
 /**/*.orig
 
 metadata/*.xml
-local_eidas_reference/ida-stub-idp
-local_eidas_reference/ida-stub-idp-repo
+local_eidas_reference/stub-idp
+local_eidas_reference/verify-stub-idp-repo
 local_eidas_reference/verify-eidas-proxy-node
 local_eidas_reference/verify-metadata
 local_eidas_reference/verify-eidas-reference

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ If the script spends a very long time "waiting for CEF SP", try the following:
 1. To check that your application is running POST to url `http://localhost:6600/verify-uk`
 1. To reach the front page of CEF, browse to `http://localhost:56000`
 
+## How to start the eidas-proxy-node in a container with stub-idp and CEF eIDAS reference
+
+* Run `./startup.sh`. Use the rebuild flags described below if this is your first time running it.
+
+The following options are available:
+
+    --follow                Will display logs in the console
+    --proxy-node-rebuild    If you want/need to build/rebuild the proxy-node image
+    --stub-idp-rebuild      If you want/need to build/rebuild the stub-idp image
+    --reference-rebuild     If you want/need to build/rebuild the CEF reference service image 
+
 ## Clicking through a journey
 
 0. Run `./automated_journey.rb` to see a journey in action

--- a/local_eidas_reference/docker/Dockerfile.stub-idp
+++ b/local_eidas_reference/docker/Dockerfile.stub-idp
@@ -1,7 +1,7 @@
 FROM verifybuild/java8:latest
 ENV LC_ALL     en_GB.UTF-8
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
-ADD ida-stub-idp /ida-stub-idp
+ADD stub-idp /ida-stub-idp
 ADD stub-idps.yml /ida-stub-idp/stub-idps.yml
 WORKDIR /ida-stub-idp
-CMD bin/ida-stub-idp
+CMD bin/stub-idp

--- a/local_eidas_reference/docker/docker-compose.yaml
+++ b/local_eidas_reference/docker/docker-compose.yaml
@@ -48,11 +48,12 @@ services:
       CERT_TYPE: encoded
       TRUSTSTORE_TYPE: encoded
       GRAPHITE_REPORTING_FREQUENCY: 24h
+      DB_URI: jdbc:postgresql://postgres:5432/postgres?user=postgres&password=password
     env_file: ./pki/stub_idp.env
     volumes:
       - ./pki:/ida-stub-idp/pki:ro
   stub-sp:
-    image: govukverify/verify-eidas-reference
+    image: govukverify/verify-eidas-reference:48
     ports:
       - "56000:8080"
     networks:
@@ -93,7 +94,7 @@ services:
       check_certificate_validity_period: "false"
       disallow_self_signed_certificate: "false"
   connector-node:
-    image: govukverify/verify-eidas-reference
+    image: govukverify/verify-eidas-reference:48
     ports:
       - "56001:8080"
     networks:
@@ -145,5 +146,12 @@ services:
     volumes:
       - ./metadata/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./pki:/usr/share/nginx/html:ro
+  postgres:
+    image: postgres
+    ports:
+      - "5432:5432"
+    networks:
+      - global
+
 networks:
   global:

--- a/local_eidas_reference/scripts/setup-ida-stub-idp.sh
+++ b/local_eidas_reference/scripts/setup-ida-stub-idp.sh
@@ -2,13 +2,12 @@
 
 # pull down stub-idp
 
-REMOTE="git@github.com:alphagov/ida-stub-idp"
-APP_NAME="ida-stub-idp"
-RUN_DIR="ida-stub-idp"
+REMOTE="git@github.com:alphagov/verify-stub-idp"
+APP_NAME="verify-stub-idp"
+RUN_DIR="verify-stub-idp"
 
-test -d "$RUN_DIR" || git clone --quiet --depth 1 "$REMOTE" "$RUN_DIR" 
+test -d "$RUN_DIR" || git clone --quiet --depth 1 "$REMOTE" "$RUN_DIR"
 
 pushd "$RUN_DIR"
   git pull --quiet
 popd
-

--- a/local_eidas_reference/scripts/setup-verify-eidas-reference.sh
+++ b/local_eidas_reference/scripts/setup-verify-eidas-reference.sh
@@ -3,7 +3,7 @@ set -ueo pipefail
 
 # pull down verify-eidas-reference
 
-REMOTE="git@github.com:alphagov/verify-eidas-reference-1.4.git"
+REMOTE="git@github.com:alphagov/verify-eidas-reference.git"
 RUN_DIR="verify-eidas-reference"
 SCRIPTS_DIR="$RUN_DIR"/scripts
 

--- a/local_eidas_reference/scripts/setup-verify-eidas-reference.sh
+++ b/local_eidas_reference/scripts/setup-verify-eidas-reference.sh
@@ -24,4 +24,5 @@ then
   "$SCRIPTS_DIR"/build_docker_image.sh
 fi
 
+test -d "$RUN_DIR/metadata-proxy" || mkdir -p $RUN_DIR/metadata-proxy
 cp $RUN_DIR/../verify-metadata/signed/local-connector/metadata.xml $RUN_DIR/metadata-proxy/metadata.xml || (echo "Could not find signed metadata file" && exit 1)

--- a/startup.sh
+++ b/startup.sh
@@ -14,30 +14,30 @@ stub_idp_rebuild=false
 
 while [ ! $# -eq 0 ]
 do
-	case "$1" in
-		--follow)
+  case "$1" in
+    --follow)
       follow=true
-			;;
-		--reference-rebuild)
+      ;;
+    --reference-rebuild)
       reference_rebuild=true
-			;;
-		--stub-idp-rebuild)
+      ;;
+    --stub-idp-rebuild)
       stub_idp_rebuild=true
-			;;
-		--proxy-node-rebuild)
+      ;;
+    --proxy-node-rebuild)
       proxy_node_rebuild=true
-			;;
+      ;;
     --build)
       reference_rebuild=true
       stub_idp_rebuild=true
       proxy_node_rebuild=true
       ;;
-		*)
+    *)
       echo "Usage $0 [--follow --proxy-node-rebuild --stub-idp-rebuild --reference-rebuild]"
-			exit 1
-			;;
-	esac
-	shift
+      exit 1
+      ;;
+  esac
+  shift
 done
 
 pushd "${PN_PROJECT_DIR}"/local_eidas_reference
@@ -70,9 +70,9 @@ pushd "${PN_PROJECT_DIR}"/local_eidas_reference
 
   if [ "$reference_rebuild" = true ]
   then
-		pushd "$reference_scripts_dir"/../docker
-    	"$reference_scripts_dir"/../docker/build_docker_image.sh
-		popd
+    pushd "$reference_scripts_dir"/../docker
+      "$reference_scripts_dir"/../docker/build_docker_image.sh
+    popd
   fi
 popd
 

--- a/startup.sh
+++ b/startup.sh
@@ -45,17 +45,16 @@ pushd "${PN_PROJECT_DIR}"/local_eidas_reference
   source "${PN_SCRIPTS_DIR}"/setup-verify-eidas-reference.sh
 
   reference_scripts_dir="${PN_PROJECT_DIR}"/local_eidas_reference/verify-eidas-reference/scripts
-
   if [ "$stub_idp_rebuild" = true ]
   then
-    test -d "ida-stub-idp-repo" || git clone --quiet --depth 1 "git@github.com:alphagov/ida-stub-idp" "ida-stub-idp-repo"
-    pushd "ida-stub-idp-repo"
+    test -d "verify-stub-idp-repo" || git clone --quiet --depth 1 "git@github.com:alphagov/verify-stub-idp" "verify-stub-idp-repo"
+    pushd "verify-stub-idp-repo"
       git pull --quiet
-      echo "rootProject.name = 'ida-stub-idp'" > settings.gradle
+      echo "rootProject.name = 'verify-stub-idp'" >> settings.gradle
       ./gradlew clean distZip -Pversion=local -PincludeDirs=configuration -x test
     popd
-    rm -rf ida-stub-idp
-    unzip ida-stub-idp-repo/build/distributions/ida-stub-idp-local.zip
+    rm -rf stub-idp
+    unzip verify-stub-idp-repo/stub-idp/build/distributions/stub-idp-local.zip
     docker build -f docker/Dockerfile.stub-idp . -t notification-stub-idp
   fi
 
@@ -71,7 +70,9 @@ pushd "${PN_PROJECT_DIR}"/local_eidas_reference
 
   if [ "$reference_rebuild" = true ]
   then
-    "$reference_scripts_dir"/build_docker_image.sh
+		pushd "$reference_scripts_dir"/../docker
+    	"$reference_scripts_dir"/../docker/build_docker_image.sh
+		popd
   fi
 popd
 
@@ -96,4 +97,3 @@ pushd "${PN_PROJECT_DIR}"/local_eidas_reference/docker
     docker-compose logs -f
   fi
 popd
-


### PR DESCRIPTION
The stub-idp has changed name from ida to verify. This commit updates
the startup script and docker-compose config to use the new name.

It also adds a postgres service to the docker-compose to make it easier
for the stub-idp to connect.

