### PR TITLE
BAU: Minor EidasAuthnRequestAppRuleTests refactoring

### DIFF
--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/EidasAuthnRequestAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/EidasAuthnRequestAppRuleTests.java
@@ -1,11 +1,11 @@
 package uk.gov.ida.notification.apprule;
 
 import org.apache.http.HttpStatus;
-import org.bouncycastle.util.Strings;
 import org.glassfish.jersey.internal.util.Base64;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.security.credential.Credential;
 import uk.gov.ida.notification.apprule.base.ProxyNodeAppRuleTestBase;
 import uk.gov.ida.notification.helpers.EidasAuthnRequestBuilder;
 import uk.gov.ida.notification.helpers.HtmlHelpers;
@@ -13,18 +13,12 @@ import uk.gov.ida.notification.saml.SamlFormMessageType;
 import uk.gov.ida.notification.saml.SamlObjectMarshaller;
 import uk.gov.ida.notification.saml.SamlObjectSigner;
 import uk.gov.ida.notification.saml.SamlParser;
+import uk.gov.ida.saml.core.test.TestCredentialFactory;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.Response;
-import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
-import java.security.KeyFactory;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
-import java.security.spec.PKCS8EncodedKeySpec;
+import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
@@ -34,32 +28,26 @@ import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_SI
 
 public class EidasAuthnRequestAppRuleTests extends ProxyNodeAppRuleTestBase {
 
-    private static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----\n";
-    private static final String END_CERT = "\n-----END CERTIFICATE-----";
     private static final String CONNECTOR_NODE_ENTITY_ID = "http://connector-node:8080/ConnectorResponderMetadata";
 
     private SamlObjectMarshaller marshaller;
     private SamlParser parser;
+    private EidasAuthnRequestBuilder eidasAuthnRequestBuilder;
     private SamlObjectSigner samlObjectSigner;
 
     @Before
     public void setup() throws Throwable {
         marshaller = new SamlObjectMarshaller();
         parser = new SamlParser();
+        eidasAuthnRequestBuilder = new EidasAuthnRequestBuilder();
 
-        String publicCert = BEGIN_CERT + TEST_RP_PUBLIC_SIGNING_CERT + END_CERT;
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(publicCert.getBytes(StandardCharsets.UTF_8));
-        X509Certificate x509certificate = (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(byteArrayInputStream);
-        PublicKey publicKey = x509certificate.getPublicKey();
-        PrivateKey privateKey = KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(Base64.decode(Strings.toByteArray(TEST_RP_PRIVATE_SIGNING_KEY))));
-
-        samlObjectSigner = new SamlObjectSigner(publicKey, privateKey, publicCert);
+        Credential signingCredential = new TestCredentialFactory(TEST_RP_PUBLIC_SIGNING_CERT, TEST_RP_PRIVATE_SIGNING_KEY).getSigningCredential();
+        samlObjectSigner = new SamlObjectSigner(signingCredential.getPublicKey(), signingCredential.getPrivateKey(), TEST_RP_PUBLIC_SIGNING_CERT);
     }
 
     @Test
     public void postBindingReturnsHubAuthnRequestForm() throws Throwable {
-        EidasAuthnRequestBuilder builder = new EidasAuthnRequestBuilder();
-        AuthnRequest eidasAuthnRequest = builder.withIssuer(CONNECTOR_NODE_ENTITY_ID).build();
+        AuthnRequest eidasAuthnRequest = eidasAuthnRequestBuilder.withIssuer(CONNECTOR_NODE_ENTITY_ID).build();
         samlObjectSigner.sign(eidasAuthnRequest);
 
         String encodedRequest = Base64.encodeAsString(marshaller.transformToString(eidasAuthnRequest));
@@ -69,8 +57,7 @@ public class EidasAuthnRequestAppRuleTests extends ProxyNodeAppRuleTestBase {
                 .post(Entity.form(postForm))
                 .readEntity(String.class);
 
-        String decodedHubAuthnRequest = HtmlHelpers.getValueFromForm(html, "saml-form", SamlFormMessageType.SAML_REQUEST);
-        AuthnRequest hubAuthnRequest = parser.parseSamlString(decodedHubAuthnRequest);
+        AuthnRequest hubAuthnRequest = getHubAuthnRequestFromHtml(html);
 
         assertEquals(eidasAuthnRequest.getID(), hubAuthnRequest.getID());
     }
@@ -100,7 +87,7 @@ public class EidasAuthnRequestAppRuleTests extends ProxyNodeAppRuleTestBase {
         Form postForm = new Form().param(SamlFormMessageType.SAML_REQUEST, encodedRequest);
 
         Response response = proxyNodeAppRule.target("/SAML2/SSO/POST").request()
-            .post(Entity.form(postForm));
+                .post(Entity.form(postForm));
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatus());
         assertThat(response.readEntity(String.class), containsString("Error handling authn request."));
@@ -108,8 +95,7 @@ public class EidasAuthnRequestAppRuleTests extends ProxyNodeAppRuleTestBase {
 
     @Test
     public void redirectBindingReturnsHubAuthnRequestForm() throws Throwable {
-        EidasAuthnRequestBuilder builder = new EidasAuthnRequestBuilder();
-        AuthnRequest eidasAuthnRequest = builder.withIssuer(CONNECTOR_NODE_ENTITY_ID).build();
+        AuthnRequest eidasAuthnRequest = eidasAuthnRequestBuilder.withIssuer(CONNECTOR_NODE_ENTITY_ID).build();
         samlObjectSigner.sign(eidasAuthnRequest);
 
         String encodedRequest = Base64.encodeAsString(marshaller.transformToString(eidasAuthnRequest));
@@ -120,8 +106,7 @@ public class EidasAuthnRequestAppRuleTests extends ProxyNodeAppRuleTestBase {
                 .get()
                 .readEntity(String.class);
 
-        String decodedHubAuthnRequest = HtmlHelpers.getValueFromForm(html, "saml-form", SamlFormMessageType.SAML_REQUEST);
-        AuthnRequest hubAuthnRequest = parser.parseSamlString(decodedHubAuthnRequest);
+        AuthnRequest hubAuthnRequest = getHubAuthnRequestFromHtml(html);
 
         assertEquals(eidasAuthnRequest.getID(), hubAuthnRequest.getID());
     }
@@ -157,5 +142,10 @@ public class EidasAuthnRequestAppRuleTests extends ProxyNodeAppRuleTestBase {
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatus());
         assertThat(response.readEntity(String.class), containsString("Error handling authn request."));
+    }
+
+    private AuthnRequest getHubAuthnRequestFromHtml(String html) throws IOException {
+        String decodedHubAuthnRequest = HtmlHelpers.getValueFromForm(html, "saml-form", SamlFormMessageType.SAML_REQUEST);
+        return parser.parseSamlString(decodedHubAuthnRequest);
     }
 }


### PR DESCRIPTION
- Made `eidasAuthnRequestBuilder` a class field
- Moved hub HTML form extracting out to a method
- Used `TestCredentialFactory` to remove all the PKI mangling