### PR TITLE
EID-1029: Run tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: required
+
+services:
+  - docker
+
+before_install:
+  - docker build -t proxy-node-tests -f Dockerfile.test .
+
+script:
+  - docker run --rm proxy-node-tests
+

--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,6 @@
 tap "cloudfoundry/tap"
 
-brew "docker"
+cask "docker"
 brew "docker-compose"
 brew "pre-commit"
 brew "xmlsectool"

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -14,6 +14,8 @@ COPY proxy-node-gateway/ proxy-node-gateway/
 COPY proxy-node-translator/ proxy-node-translator/
 COPY stub-connector/ stub-connector/
 
-RUN gradle --no-daemon compileTestJava
+# Travis needs to get the libraries from public repositories
+ENV VERIFY_USE_PUBLIC_BINARIES true
+RUN gradle --no-daemon --quiet compileTestJava
 
-CMD gradle --no-daemon clean test
+CMD gradle --no-daemon --quiet clean test

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,19 @@
+# Base builder image
+
+FROM gradle:jdk8 AS build
+WORKDIR /app
+USER root
+ENV GRADLE_USER_HOME ~/.gradle
+
+COPY build.gradle build.gradle
+COPY settings.gradle settings.gradle
+
+COPY proxy-node-shared/ proxy-node-shared/
+COPY proxy-node-test/ proxy-node-test/
+COPY proxy-node-gateway/ proxy-node-gateway/
+COPY proxy-node-translator/ proxy-node-translator/
+COPY stub-connector/ stub-connector/
+
+RUN gradle --no-daemon compileTestJava
+
+CMD gradle --no-daemon clean test

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,6 @@ subprojects {
                 "net.sourceforge.htmlunit:htmlunit:2.28",
                 "uk.gov.ida:common-test-utils:${utils_version}",
                 "uk.gov.ida:saml-metadata-bindings-test:${saml_libs_version}",
-                "uk.gov.verify:saml-test-utils:${opensaml_version}-46",
                 "io.dropwizard:dropwizard-testing:${dropwizard_version}",
         )
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip


### PR DESCRIPTION
- Create `.travis.yml` to build and run proxy node tests.
- Use `gradle` Docker image to build a test image.
- Run all unit and `AppRule` tests using the test image.
- Update the `Brewfile` to install the right kind of Docker.