### PR TITLE
EID-1096: Add Translator to startup and docker-compose.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,27 @@ services:
     env_file: ./.local_pki/proxy_node.env
     volumes:
       - ./.local_pki:/verify-eidas-proxy-node/pki:ro
-
+  proxy-node-translator:
+    build:
+      context: .
+      args:
+        component: proxy-node-translator
+    ports:
+      - "6300:80"
+    environment:
+      PORT: 80
+      PROXY_NODE_ENTITY_ID: https://dev-hub.local
+      PROXY_NODE_RESPONSE_ENDPOINT: http://localhost:6100/SAML2/SSO/Response/POST
+      HUB_URL: http://localhost:6200/stub-idp-demo/SAML2/SSO
+      HUB_METADATA_URL: http://proxy-node-metadata/metadata_for_hub.xml
+      PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_URL: http://proxy-node-metadata/metadata_for_connector_node.xml
+      CONNECTOR_NODE_URL: http://localhost:5000/SAML2/Response/POST
+      CONNECTOR_NODE_ISSUER_ID: http://localhost:5000/Metadata
+      CONNECTOR_NODE_METADATA_URL: http://stub-connector/Metadata
+      CONNECTOR_NODE_ENTITY_ID: http://localhost:5000/Metadata
+    env_file: ./.local_pki/proxy_node.env
+    volumes:
+    - ./pki:/verify-eidas-proxy-node/pki:ro
   stub-connector:
     build:
       context: .


### PR DESCRIPTION
The Proxy Node was refactored with changes to the docker configuration and startup.
The new Translator service was not included in the startup.
Added the Translator service to docker-compose.
Tested the end-to-end flow including Translator by sending the hub response to Translator rather than Gateway.

Co-authored-by: Chris Wynne <christopher.wynne@digital.cabinet-office.gov.uk>
Co-authored-by: dbes-gds <daniel.besbrode@digital.cabinet-office.gov.uk>